### PR TITLE
Made makeRequest public to allow for arbitrary requests

### DIFF
--- a/src/Mochaka/Shopify/Shopify.php
+++ b/src/Mochaka/Shopify/Shopify.php
@@ -97,12 +97,21 @@ class Shopify
      */
     public function getProductById($productId)
     {
-        return $this->makeRequest('GET', 'products/' . $productId . '.json')['product'];
+        $data = $this->makeRequest('GET', 'products/' . $productId . '.json');
+        return isset($data['product']) ? $data['product'] : $data;
     }
 
+    /**
+     * returns variant information by id
+     *
+     * @param  int $productId
+     *
+     * @return array
+     */
     public function getVariantById($productId)
     {
-        return $this->makeRequest('GET', 'variants/' . $productId . '.json')['variant'];
+        $data = $this->makeRequest('GET', 'variants/' . $productId . '.json');
+        return isset($data['variant']) ? $data['variant'] : $data;
     }
 
     /**

--- a/src/Mochaka/Shopify/Shopify.php
+++ b/src/Mochaka/Shopify/Shopify.php
@@ -37,7 +37,7 @@ class Shopify
      *
      * @return array
      */
-    private function makeRequest($method, $page, $data = [])
+    public function makeRequest($method, $page, $data = [])
     {
         $url = $this->url . "/" . $page;
 


### PR DESCRIPTION
In my opinion, `Mochaka\Shopify\Shopify::makeRequest` should be a public method to allow for arbitrary requests to the Shopify API, since the API wrapper doesn't have convenience methods for all possible endpoints (nor is it required).